### PR TITLE
Fix for SSLv3 problems with PhantomJS

### DIFF
--- a/lib/engines/icomoon-phantomjs.js
+++ b/lib/engines/icomoon-phantomjs.js
@@ -45,6 +45,7 @@ IcoMoonPhantomJsEngine.prototype = {
       function execIcoMoon (cb) {
         var tmpPath = tmp.path;
         // TODO: Move onto programatic API once its coded
+        // temporary fix for the SSLv3 vulnerability (POODLE)
         exec(quote(['phantomjs', '--ssl-protocol=tlsv1', icomoonPath, tmpPath]), cb);
       },
       // Handle any stderr errors


### PR DESCRIPTION
The icomoon engine is currently not working because of the SSL vulnerability (POODLE). Since icomoon changed their protocol to TLS lately.
Maybe this is related to SSL problems in PhantomJS. See ariya/phantomjs#12676 for details. Until the SSL bug is fixed in PhantomJS, we should switch to another SSL protocol.
