### PR TITLE
Update dependency for node >0.10 compatiblity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: node_js
 node_js:
+  - "0.12"
   - "0.11"
   - "0.10"
   - "0.8"
+  - "iojs"
+
 matrix:
   allow_failures:
     - node_js: "0.11"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "async": "~0.2.8",
     "icomoon-phantomjs": "~0.4.0",
-    "temporary": "0.0.5",
+    "temporary": "0.0.8",
     "request": "~2.21.0",
     "node-zip": "~1.0.1",
     "shell-quote": "~1.4.1"


### PR DESCRIPTION
This is the same issue with dependance on [temporary](https://www.npmjs.com/package/temporary) as twolfson/icomoon-phantomjs#11, updating to the latest version resolves the issue.
